### PR TITLE
Add -SourceDir option for copying from a local git repo (or other source copy).

### DIFF
--- a/hercules-buildall.ps1
+++ b/hercules-buildall.ps1
@@ -788,7 +788,7 @@ try {
     } else {
         Write-Output "$Flavor directory exists, skipping '$gethow'."
     }
-    Remove-Variable -Name getfrom, gethow, getto
+    Remove-Variable -Name getfrom, gethow, getto, getverb
 
     cd $Flavor
 


### PR DESCRIPTION
I wanted to be able to build Hercules without committing my changes to my clone of the SDL Hyperion repo.  I have several reasons for not wanting to commit, but the biggest one is that I'm testing experiments, and they're not always ready for committing.

This update adds a -SourceDir option to specify the location of the directory where the source code should be copied from.  After the copying, all processing is just the same as if the code had been cloned from GitHub.  -SourceDir is mutually incompatible with -GitRepo, -GitBranch, and -GitCommit, and the code reports an error and quits if they are specified together.

I'll understand if this is too esoteric a change for you to accept.  But since I needed it, I figured I'd offer it to you.